### PR TITLE
Fix Python 3 syntax error

### DIFF
--- a/pcdet/datasets/kitti/kitti_object_eval_python/evaluate.py
+++ b/pcdet/datasets/kitti/kitti_object_eval_python/evaluate.py
@@ -1,7 +1,7 @@
 import time
 import fire
 
-import .kitti_common as kitti
+from . import kitti_common as kitti
 from .eval import get_official_eval_result, get_coco_eval_result
 
 

--- a/pcdet/models/model_utils/pytorch_utils.py
+++ b/pcdet/models/model_utils/pytorch_utils.py
@@ -1,5 +1,6 @@
 import torch
 import torch.nn as nn
+import sys
 from collections import OrderedDict
 from typing import List, Tuple
 


### PR DESCRIPTION
% `python3`
```
>>> import .kitti_common as kitti
  File "<stdin>", line 1
    import .kitti_common as kitti
```