### PR TITLE
changing variable name for inference start time for proper latency calculation when using --infer_time

### DIFF
--- a/tools/eval_utils/eval_utils.py
+++ b/tools/eval_utils/eval_utils.py
@@ -59,7 +59,7 @@ def eval_one_epoch(cfg, args, model, dataloader, epoch_id, logger, dist_test=Fal
         load_data_to_gpu(batch_dict)
 
         if getattr(args, 'infer_time', False):
-            start_time = time.time()
+            inference_start_time = time.time()
 
         with torch.no_grad():
             pred_dicts, ret_dict = model(batch_dict)
@@ -67,7 +67,7 @@ def eval_one_epoch(cfg, args, model, dataloader, epoch_id, logger, dist_test=Fal
         disp_dict = {}
 
         if getattr(args, 'infer_time', False):
-            inference_time = time.time() - start_time
+            inference_time = time.time() - inference_start_time
             infer_time_meter.update(inference_time * 1000)
             # use ms to measure inference time
             disp_dict['infer_time'] = f'{infer_time_meter.val:.2f}({infer_time_meter.avg:.2f})'


### PR DESCRIPTION
sec_per_example is calculated from different start time than the experiment start and logs wrong value. Really short sec_per_example was also raised in these issues  #1464  and #1468.

### steps required to reproduce the bug

`python3 test.py --cfg_file cfgs/nuscenes_models/cbgs_dyn_pp_centerpoint.yaml --ckpt ../checkpoints/cbgs_pp_centerpoint_nds6070.pth --infer_time`
is showing
`2023-10-03 10:40:45,533   INFO  *************** EPOCH 6070 EVALUATION *****************
eval: 100%|█████████████████████████████████████████████████████████████████████████████████████████| 162/162 [00:17<00:00,  9.33it/s, infer_time=58.17(101.47), recall_0.3=(0, 4375) / 5519]
2023-10-03 10:41:02,902   INFO  *************** Performance of EPOCH 6070 *****************
2023-10-03 10:41:02,902   INFO  Generate label finished(sec_per_example: 0.0005 second).
`

This fix solves and shows the correct sec_per_example value. 
`2023-10-03 10:42:12,475   INFO  *************** EPOCH 6070 EVALUATION *****************
eval: 100%|█████████████████████████████████████████████████████████████████████████████████████████| 162/162 [00:17<00:00,  9.22it/s, infer_time=53.93(101.71), recall_0.3=(0, 4375) / 5519]
2023-10-03 10:42:30,057   INFO  *************** Performance of EPOCH 6070 *****************
2023-10-03 10:42:30,057   INFO  Generate label finished(sec_per_example: 0.1085 second).
`