### PR TITLE
Specify kornia version 0.6.5 in cu116.Dockerfile

### DIFF
--- a/docker/cu116.Dockerfile
+++ b/docker/cu116.Dockerfile
@@ -62,7 +62,7 @@ RUN pip3 install torch==1.13.1+cu116 torchvision==0.14.1+cu116 torchaudio==0.13.
 ENV TORCH_CUDA_ARCH_LIST="3.5;5.0;6.0;6.1;7.0;7.5;8.0;8.6+PTX"
     
 # OpenPCDet
-RUN pip3 install numpy==1.23.0 llvmlite numba tensorboardX easydict pyyaml scikit-image tqdm SharedArray open3d mayavi av2 kornia pyquaternion
+RUN pip3 install numpy==1.23.0 llvmlite numba tensorboardX easydict pyyaml scikit-image tqdm SharedArray open3d mayavi av2 kornia==0.6.5 pyquaternion
 RUN pip3 install spconv-cu116
 
 RUN git clone https://github.com/open-mmlab/OpenPCDet.git


### PR DESCRIPTION
This merge request updates the version of kornia in the cu116.Dockerfile to 0.6.5. This change was necessary because not specifying the version of kornia was causing issues with Docker, preventing the container from building and running correctly.