### PR TITLE
Update data config path in custom pv_rcnn.yaml model

### DIFF
--- a/tools/cfgs/custom_models/pv_rcnn.yaml
+++ b/tools/cfgs/custom_models/pv_rcnn.yaml
@@ -1,7 +1,7 @@
 CLASS_NAMES: ['Vehicle', 'Pedestrian', 'Cyclist']
 
 DATA_CONFIG:
-    _BASE_CONFIG_: ../dataset_configs/custom_dataset.yaml
+    _BASE_CONFIG_: cfgs/dataset_configs/custom_dataset.yaml
 
 MODEL:
     NAME: PVRCNN


### PR DESCRIPTION
This pull request updates the relative path for the dataset config in the custom `pv_rcnn.yaml` model. The path was changed from `../dataset_configs/custom_dataset.yaml` to `cfgs/dataset_configs/custom_dataset.yaml` to correctly reference the dataset configuration file when calling `train.py` from the `tools` directory.