### PR TITLE
Replace deprecated np.int with np.int_ and np.float with np.float64

### DIFF
--- a/pcdet/datasets/augmentor/database_sampler.py
+++ b/pcdet/datasets/augmentor/database_sampler.py
@@ -178,24 +178,24 @@ class DataBaseSampler(object):
             paste_order = boxes3d[:,0].argsort()
             paste_order = paste_order[::-1]
         else:
-            paste_order = np.arange(len(boxes3d),dtype=np.int)
+            paste_order = np.arange(len(boxes3d),dtype=np.int_)
 
         if 'reverse' in kitti_img_aug_type:
             paste_order = paste_order[::-1]
 
-        paste_mask = -255 * np.ones(image.shape[:2], dtype=np.int)
-        fg_mask = np.zeros(image.shape[:2], dtype=np.int)
-        overlap_mask = np.zeros(image.shape[:2], dtype=np.int)
-        depth_mask = np.zeros((*image.shape[:2], 2), dtype=np.float)
+        paste_mask = -255 * np.ones(image.shape[:2], dtype=np.int_)
+        fg_mask = np.zeros(image.shape[:2], dtype=np.int_)
+        overlap_mask = np.zeros(image.shape[:2], dtype=np.int_)
+        depth_mask = np.zeros((*image.shape[:2], 2), dtype=np.float64)
         points_2d, depth_2d = data_dict['calib'].lidar_to_img(data_dict['points'][:,:3])
         points_2d[:,0] = np.clip(points_2d[:,0], a_min=0, a_max=image.shape[1]-1)
         points_2d[:,1] = np.clip(points_2d[:,1], a_min=0, a_max=image.shape[0]-1)
-        points_2d = points_2d.astype(np.int)
+        points_2d = points_2d.astype(np.int_)
         for _order in paste_order:
             _box2d = boxes2d[_order]
             image[_box2d[1]:_box2d[3],_box2d[0]:_box2d[2]] = crop_feat[_order]
             overlap_mask[_box2d[1]:_box2d[3],_box2d[0]:_box2d[2]] += \
-                (paste_mask[_box2d[1]:_box2d[3],_box2d[0]:_box2d[2]] > 0).astype(np.int)
+                (paste_mask[_box2d[1]:_box2d[3],_box2d[0]:_box2d[2]] > 0).astype(np.int_)
             paste_mask[_box2d[1]:_box2d[3],_box2d[0]:_box2d[2]] = _order
 
             if 'cover' in kitti_img_aug_use_type:
@@ -255,22 +255,22 @@ class DataBaseSampler(object):
             sampled_gt_boxes[idx] = box3d_lidar[0]
             sampled_gt_boxes2d[idx] = box2d[0]
 
-        obj_idx = idx * np.ones(len(obj_points), dtype=np.int)
+        obj_idx = idx * np.ones(len(obj_points), dtype=np.int_)
 
         # copy crops from images
         img_path = self.root_path /  f'training/image_2/{info["image_idx"]}.png'
         raw_image = io.imread(img_path)
         raw_image = raw_image.astype(np.float32)
         raw_center = info['bbox'].reshape(2,2).mean(0)
-        new_box = sampled_gt_boxes2d[idx].astype(np.int)
+        new_box = sampled_gt_boxes2d[idx].astype(np.int_)
         new_shape = np.array([new_box[2]-new_box[0], new_box[3]-new_box[1]])
-        raw_box = np.concatenate([raw_center-new_shape/2, raw_center+new_shape/2]).astype(np.int)
+        raw_box = np.concatenate([raw_center-new_shape/2, raw_center+new_shape/2]).astype(np.int_)
         raw_box[0::2] = np.clip(raw_box[0::2], a_min=0, a_max=raw_image.shape[1])
         raw_box[1::2] = np.clip(raw_box[1::2], a_min=0, a_max=raw_image.shape[0])
         if (raw_box[2]-raw_box[0])!=new_shape[0] or (raw_box[3]-raw_box[1])!=new_shape[1]:
             new_center = new_box.reshape(2,2).mean(0)
             new_shape = np.array([raw_box[2]-raw_box[0], raw_box[3]-raw_box[1]])
-            new_box = np.concatenate([new_center-new_shape/2, new_center+new_shape/2]).astype(np.int)
+            new_box = np.concatenate([new_center-new_shape/2, new_center+new_shape/2]).astype(np.int_)
 
         img_crop2d = raw_image[raw_box[1]:raw_box[3],raw_box[0]:raw_box[2]] / 255
 
@@ -320,8 +320,8 @@ class DataBaseSampler(object):
             pass
         elif self.img_aug_type == 'kitti':
             obj_index_list, crop_boxes2d = [], []
-            gt_number = gt_boxes_mask.sum().astype(np.int)
-            gt_boxes2d = data_dict['gt_boxes2d'][gt_boxes_mask].astype(np.int)
+            gt_number = gt_boxes_mask.sum().astype(np.int_)
+            gt_boxes2d = data_dict['gt_boxes2d'][gt_boxes_mask].astype(np.int_)
             gt_crops2d = [data_dict['images'][_x[1]:_x[3],_x[0]:_x[2]] for _x in gt_boxes2d]
 
             img_aug_gt_dict = {
@@ -351,7 +351,7 @@ class DataBaseSampler(object):
     def copy_paste_to_image(self, img_aug_gt_dict, data_dict, points):
         if self.img_aug_type == 'kitti':
             obj_points_idx = np.concatenate(img_aug_gt_dict['obj_index_list'], axis=0)
-            point_idxes = -1 * np.ones(len(points), dtype=np.int)
+            point_idxes = -1 * np.ones(len(points), dtype=np.int_)
             point_idxes[:obj_points_idx.shape[0]] = obj_points_idx
 
             data_dict['gt_boxes2d'] = np.concatenate([img_aug_gt_dict['gt_boxes2d'], np.array(img_aug_gt_dict['crop_boxes2d'])], axis=0)

--- a/pcdet/models/backbones_2d/base_bev_backbone.py
+++ b/pcdet/models/backbones_2d/base_bev_backbone.py
@@ -57,7 +57,7 @@ class BaseBEVBackbone(nn.Module):
                         nn.ReLU()
                     ))
                 else:
-                    stride = np.round(1 / stride).astype(np.int)
+                    stride = np.round(1 / stride).astype(np.int_)
                     self.deblocks.append(nn.Sequential(
                         nn.Conv2d(
                             num_filters[idx], num_upsample_filters[idx],
@@ -158,7 +158,7 @@ class BaseBEVBackboneV1(nn.Module):
                         nn.ReLU()
                     ))
                 else:
-                    stride = np.round(1 / stride).astype(np.int)
+                    stride = np.round(1 / stride).astype(np.int_)
                     self.deblocks.append(nn.Sequential(
                         nn.Conv2d(
                             num_filters[idx], num_upsample_filters[idx],
@@ -296,7 +296,7 @@ class BaseBEVResBackbone(nn.Module):
                         nn.ReLU()
                     ))
                 else:
-                    stride = np.round(1 / stride).astype(np.int)
+                    stride = np.round(1 / stride).astype(np.int_)
                     self.deblocks.append(nn.Sequential(
                         nn.Conv2d(
                             num_filters[idx], num_upsample_filters[idx],


### PR DESCRIPTION
Purpose:

This PR addresses the deprecation of np.int and np.float in newer versions of NumPy. These aliases have been deprecated and may cause warnings or errors when i trained BEVFusion model. The latest version of the nuScenes™ devkit, which is required for training BEV models, uses NumPy version 1.22.0 or higher. As a result, older syntax like np.int is deprecated and no longer supported.
![图片](https://github.com/user-attachments/assets/5ee4971a-62c7-4214-a29f-b654e1b4dfa7)


Changes:

    Replaced all instances of np.int with np.int_.
    Replaced all instances of np.float with np.float64.

Testing:

All existing tests have passed after the changes were made, confirming that the code remains functional and correct.