### PR TITLE
Adding required dependencys and restrict to numpy<2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy
+numpy<2
 llvmlite
 numba
 torch>=1.1
@@ -11,3 +11,6 @@ torchvision
 SharedArray
 opencv-python
 pyquaternion
+av2
+kornia==0.5.8
+spconv-cu120


### PR DESCRIPTION
Kornia needs a special version to run and numpy needs to reduced to numpy<2 for spconv to work. To make it simpler to get started i would include them in the requirements file. If someone wants to build all these by themselves they would probably not use the requirements.txt so i think its adequate to include them here.