### PR TITLE
remove multi processing spawn process to avoid conflict with torch.dist.launch

### DIFF
--- a/pcdet/utils/common_utils.py
+++ b/pcdet/utils/common_utils.py
@@ -187,8 +187,13 @@ def init_dist_slurm(tcp_port, local_rank, backend='nccl'):
 
 
 def init_dist_pytorch(tcp_port, local_rank, backend='nccl'):
-    if mp.get_start_method(allow_none=True) is None:
-        mp.set_start_method('spawn')
+    # Un-commenting mp spawn below will lead to high variance in GPU usage across devices
+    # Also, dataloader initialization will lead to huge GPU:0 usage
+    # Because only one of torch.distributed.launch OR torch.multiprocessing
+    # is needed for correctly scheduling multi-gpu training. dist_train.sh already uses the former
+    # if mp.get_start_method(allow_none=True) is None:
+    #     mp.set_start_method('spawn')
+
     # os.environ['MASTER_PORT'] = str(tcp_port)
     # os.environ['MASTER_ADDR'] = 'localhost'
     num_gpus = torch.cuda.device_count()


### PR DESCRIPTION
TLDR; we should either torch multiprocessing spawn or torch distributed launch for invoking processes for each gpu

This PR will help improve the following symptoms
1. During dataloader initialization, the main GPU memory usage spikes. For 40 workers, I saw > 16GB being used for basically no reason. After the fix, GPU:0 take ~300MB which is for some communication related purpose I think and not dependent on num_workers
2. Training time per iteration is very slow. This can be seen from the screenshot shown below

![image](https://github.com/user-attachments/assets/ea72c1fa-71d4-45de-98b4-5e2e09041522)

Testing:
1. I tested the code by using cached data and feeding the same samples to each GPU. With this I verified that all GPUs use the same memory now (GPU:0 still takes ~300 MB more being the primary GPU)
2. The dataloader initialization is also very fast now with no spike in memory usage on GPU:0


