### PR TITLE
datatype mismatch was creating incorrect gt_database

### DIFF
--- a/pcdet/datasets/custom/custom_dataset.py
+++ b/pcdet/datasets/custom/custom_dataset.py
@@ -193,7 +193,8 @@ class CustomDataset(DatasetTemplate):
             for i in range(num_obj):
                 filename = '%s_%s_%d.bin' % (sample_idx, names[i], i)
                 filepath = database_save_path / filename
-                gt_points = points[point_indices[i] > 0]
+                gt_points = points[point_indices[i] > 0].astype(np.float32)
+                gt_boxes[i, :3] = gt_boxes[i, :3].astype(np.float32)
 
                 gt_points[:, :3] -= gt_boxes[i, :3]
                 with open(filepath, 'w') as f:


### PR DESCRIPTION
datatype mismatch was creating incorrect gt_database for custom dataset.
Made both gt_points data type and gt_boxes datatypes consistent for the creation of custom gt_database with correct bin files